### PR TITLE
Remove Unused Image Crate Features

### DIFF
--- a/wfc-image/Cargo.toml
+++ b/wfc-image/Cargo.toml
@@ -15,7 +15,7 @@ parallel = ["wfc/parallel"]
 
 [dependencies]
 wfc = { path = "../wfc", version = "0.10" }
-image = "0.23"
+image = { version = "0.23", default-features = false, features = ["png"] }
 coord_2d = "0.3"
 grid_2d = "0.15"
 rand = "0.8"


### PR DESCRIPTION
This PR removes default features from the image crate, which was pulling in about 15 or so dependencies that were not used in wfc_image.
I am reducing some dependencies in some code I'm writing, and I noticed that this could be done in wfc_image, if you are interested in accepting the change. I can always maintain my own fork if not.